### PR TITLE
Override prompt prefix separator

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -32,6 +32,10 @@ import (
 	"strings"
 )
 
+var (
+	prefixSeparator string = `: `
+)
+
 // Basic gets input and if required tests to ensure input was given.
 func Basic(prefix string, required bool) (string, error) {
 	return Custom(prefix, func(input string) (string, bool) {
@@ -92,7 +96,7 @@ func Custom(prefix string, test func(string) (string, bool)) (string, error) {
 	defer term.Close()
 
 	for !ok {
-		input, err = term.Prompt(prefix + ": ")
+		input, err = term.Prompt(prefix + prefixSeparator)
 		if err != nil && err != io.EOF {
 			return "", err
 		}
@@ -115,11 +119,17 @@ func Password(prefix string) (string, error) {
 	defer term.Close()
 
 	for input == "" {
-		input, err = term.Password(prefix + ": ")
+		input, err = term.Password(prefix + prefixSeparator)
 		if err != nil && err != io.EOF {
 			return "", err
 		}
 	}
 
 	return input, nil
+}
+
+//OverrideSeparator is used to modify the separator injected into a prompt when a prefix is used
+func OverrideSeparator(separator string) error {
+	prefixSeparator = separator
+	return nil
 }


### PR DESCRIPTION
Added a function to allow for overriding the separator injected into a prompt when a prefix is provided

A simple little addition which allows for a little more customization when using prefixes on prompts.
