### PR TITLE
Let prompt work on more BSDs

### DIFF
--- a/ansi_unix.go
+++ b/ansi_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd openbsd netbsd dragonfly
 
 // Copyright 2013-2015 Bowery, Inc.
 

--- a/buffer_unix.go
+++ b/buffer_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd openbsd netbsd dragonfly 
 
 // Copyright 2013-2015 Bowery, Inc.
 

--- a/keys_unix.go
+++ b/keys_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd openbsd netbsd dragonfly
 
 // Copyright 2013-2015 Bowery, Inc.
 

--- a/term_bsd.go
+++ b/term_bsd.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd
+// +build darwin freebsd openbsd netbsd dragonfly
 
 // Copyright 2013-2015 Bowery, Inc.
 

--- a/term_unix.go
+++ b/term_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd openbsd netbsd dragonfly
 
 // Copyright 2013-2015 Bowery, Inc.
 


### PR DESCRIPTION
Also modify the test so we use the local files vs having to use the lib in GOPATH. Not sure if this is the proper fix, or if I should be operating out of GOPATH (git clone github.com/bowery/prompt.git $GOPATH/blablabl style)

Let me know, and I will drop the change to the test file if needed.