### PR TITLE
Use typed ioctls on Solaris

### DIFF
--- a/term_solaris_ioctl.go
+++ b/term_solaris_ioctl.go
@@ -1,0 +1,37 @@
+// +build solaris
+
+// Copyright 2017 Attila Fülöp <attila@fueloep.org>
+
+package prompt
+
+import (
+	"os"
+	"golang.org/x/sys/unix"
+
+)
+
+type Termios unix.Termios
+
+// setTermios does the system dependent ioctl calls
+func setTermios(fd uintptr, req uintptr, termios *Termios) error {
+	return unix.IoctlSetTermios(int(fd), int(req), (*unix.Termios)(termios))
+}
+
+// getTermios does the system dependent ioctl calls
+func getTermios(fd uintptr, req uintptr) (*Termios, error) {
+	termios, err := unix.IoctlGetTermios(int(fd), int(req))
+	if err != nil {
+		return nil, err
+	}
+	return (*Termios)(termios), nil
+}
+
+// TerminalSize retrieves the cols/rows for the terminal connected to out.
+func TerminalSize(out *os.File) (int, int, error) {
+	ws, err := unix.IoctlGetWinsize(int(out.Fd()), unix.TIOCGWINSZ)
+
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(ws.Col), int(ws.Row), nil
+}

--- a/term_solaris_ioctl.go
+++ b/term_solaris_ioctl.go
@@ -1,6 +1,6 @@
 // +build solaris
 
-// Copyright 2017 Attila Fülöp <attila@fueloep.org>
+// Copyright 2017 Bowery, Inc.
 
 package prompt
 

--- a/term_unix.go
+++ b/term_unix.go
@@ -1,7 +1,6 @@
 // +build linux darwin freebsd openbsd netbsd dragonfly solaris
 
 // Copyright 2013-2015 Bowery, Inc.
-// Copyright 2017 Attila Fülöp <attila@fueloep.org>
 
 package prompt
 

--- a/term_unix.go
+++ b/term_unix.go
@@ -1,6 +1,7 @@
 // +build linux darwin freebsd openbsd netbsd dragonfly solaris
 
 // Copyright 2013-2015 Bowery, Inc.
+// Copyright 2017 Attila Fülöp <attila@fueloep.org>
 
 package prompt
 
@@ -8,7 +9,6 @@ import (
 	"bufio"
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 var unsupported = []string{"", "dumb", "cons25"}
@@ -26,27 +26,6 @@ func supportedTerminal() bool {
 	return true
 }
 
-// winsize contains the size for the terminal.
-type winsize struct {
-	rows   uint16
-	cols   uint16
-	xpixel uint16
-	ypixel uint16
-}
-
-// TerminalSize retrieves the cols/rows for the terminal connected to out.
-func TerminalSize(out *os.File) (int, int, error) {
-	ws := new(winsize)
-
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, out.Fd(),
-		uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
-	if err != 0 {
-		return 0, 0, err
-	}
-
-	return int(ws.cols), int(ws.rows), nil
-}
-
 // IsNotTerminal checks if an error is related to io not being a terminal.
 func IsNotTerminal(err error) bool {
 	if err == syscall.ENOTTY {
@@ -60,7 +39,7 @@ func IsNotTerminal(err error) bool {
 type terminal struct {
 	supported    bool
 	simpleReader *bufio.Reader
-	origMode     syscall.Termios
+	origMode     Termios
 }
 
 // NewTerminal creates a terminal and sets it to raw input mode.
@@ -75,16 +54,15 @@ func NewTerminal() (*Terminal, error) {
 	if !supportedTerminal() {
 		return term, nil
 	}
-
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, term.In.Fd(),
-		uintptr(tcgets), uintptr(unsafe.Pointer(&term.origMode)))
-	if err != 0 {
+	t, err := getTermios(term.In.Fd(), uintptr(tcgets))
+	if err != nil {
 		if IsNotTerminal(err) {
 			return term, nil
 		}
 
 		return nil, err
 	}
+	term.origMode = *t
 	mode := term.origMode
 	term.supported = true
 
@@ -105,9 +83,8 @@ func NewTerminal() (*Terminal, error) {
 	mode.Cc[syscall.VMIN] = 1
 	mode.Cc[syscall.VTIME] = 0
 
-	_, _, err = syscall.Syscall(syscall.SYS_IOCTL, term.In.Fd(),
-		uintptr(tcsetsf), uintptr(unsafe.Pointer(&mode)))
-	if err != 0 {
+	err = setTermios(term.In.Fd(), uintptr(tcsetsf), &mode)
+	if err != nil {
 		return nil, err
 	}
 
@@ -137,9 +114,8 @@ func (term *Terminal) GetPassword(prefix string) (string, error) {
 // Close disables the terminals raw input.
 func (term *Terminal) Close() error {
 	if term.supported {
-		_, _, err := syscall.Syscall(syscall.SYS_IOCTL, term.In.Fd(),
-			uintptr(tcsets), uintptr(unsafe.Pointer(&term.origMode)))
-		if err != 0 {
+		err := setTermios(term.In.Fd(), uintptr(tcsets), &term.origMode)
+		if err != nil {
 			return err
 		}
 	}

--- a/term_unix_ioctl.go
+++ b/term_unix_ioctl.go
@@ -1,7 +1,6 @@
 // +build linux darwin freebsd openbsd netbsd dragonfly
 
 // Copyright 2013-2015 Bowery, Inc.
-// Copyright 2017 Attila Fülöp <attila@fueloep.org>
 
 package prompt
 
@@ -9,7 +8,6 @@ import (
 	"os"
 	"syscall"
 	"unsafe"
-	"errors"
 )
 
 type Termios syscall.Termios
@@ -21,7 +19,7 @@ func getTermios(fd uintptr, req uintptr) (*Termios, error) {
 		uintptr(unsafe.Pointer(termios)))
 
 	if err != 0 {
-		return nil, errors.New(err.Error())
+		return nil, err
 	}
 	return (*Termios)(termios), nil
 }
@@ -32,7 +30,7 @@ func setTermios(fd uintptr, req uintptr, termios *Termios) error {
 		uintptr(unsafe.Pointer(termios)))
 
 	if err != 0 {
-		return errors.New(err.Error())
+		return err
 	}
 	return nil
 }
@@ -52,7 +50,7 @@ func TerminalSize(out *os.File) (int, int, error) {
 	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, out.Fd(),
 		uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
 	if err != 0 {
-		return 0, 0, errors.New(err.Error())
+		return 0, 0, err
 	}
 	return int(ws.cols), int(ws.rows), nil
 }

--- a/term_unix_ioctl.go
+++ b/term_unix_ioctl.go
@@ -1,0 +1,58 @@
+// +build linux darwin freebsd openbsd netbsd dragonfly
+
+// Copyright 2013-2015 Bowery, Inc.
+// Copyright 2017 Attila Fülöp <attila@fueloep.org>
+
+package prompt
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+	"errors"
+)
+
+type Termios syscall.Termios
+
+// setTermios does the system dependent ioctl calls
+func getTermios(fd uintptr, req uintptr) (*Termios, error) {
+	termios := new(syscall.Termios)
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, req,
+		uintptr(unsafe.Pointer(termios)))
+
+	if err != 0 {
+		return nil, errors.New(err.Error())
+	}
+	return (*Termios)(termios), nil
+}
+
+// setTermios does the system dependent ioctl calls
+func setTermios(fd uintptr, req uintptr, termios *Termios) error {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, req,
+		uintptr(unsafe.Pointer(termios)))
+
+	if err != 0 {
+		return errors.New(err.Error())
+	}
+	return nil
+}
+
+// winsize contains the size for the terminal.
+type winsize struct {
+	rows   uint16
+	cols   uint16
+	xpixel uint16
+	ypixel uint16
+}
+
+// TerminalSize retrieves the cols/rows for the terminal connected to out.
+func TerminalSize(out *os.File) (int, int, error) {
+	ws := new(winsize)
+
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, out.Fd(),
+		uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
+	if err != 0 {
+		return 0, 0, errors.New(err.Error())
+	}
+	return int(ws.cols), int(ws.rows), nil
+}


### PR DESCRIPTION
Solaris go has no syscall.SYS_IOCTL, we have to use typed ioctls instead. This fixes the ```undefined: syscall.SYS_IOCTL``` errors I'm seeing on SmartOS with pksrc 16Q4 go 2.7.4.  I'm wondering on what OS and go combination #7 worked.

See https://github.com/golang/go/issues/12574 and https://github.com/golang/sys/commit/584c5fee74f2fb64acbbd2fc9d1db29c4237d311