### PR TITLE
fixed compilation on freebsd 32bit machine

### DIFF
--- a/ioctl_unix.go
+++ b/ioctl_unix.go
@@ -47,7 +47,8 @@ func getTermios(fd uintptr) (*unix.Termios, error) {
 // setTermios sets the termios settings for the terminal descriptor,
 // optionally flushing the buffer before setting.
 func setTermios(fd uintptr, flush bool, mode *unix.Termios) error {
-	req := tcsets
+	var req int64
+	req = tcsets
 	if flush {
 		req = tcsetsf
 	}


### PR DESCRIPTION
When tried to install govendor on a freebsd 32bit machine, i got errors in this dependency.
This fixed the issue.