### PR TITLE
On Solaris/Illumos, the second param to IoctlSetTermios needs to be a uint

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - [Gereon Frey](https://github.com/gfrey)
 - [Aaron Bieber](https://github.com/qbit)
 - [Ricky Medina](https://github.com/r-medina)
+- [sungo](https://github.com/sungo)

--- a/ioctl_solaris.go
+++ b/ioctl_solaris.go
@@ -37,5 +37,5 @@ func setTermios(fd uintptr, flush bool, mode *unix.Termios) error {
 		req = tcsetsf
 	}
 
-	return unix.IoctlSetTermios(int(fd), req, mode)
+	return unix.IoctlSetTermios(int(fd), uint(req), mode)
 }


### PR DESCRIPTION
Tested via solaris/amd64 cross-compile and SmartOS 17.3.0